### PR TITLE
Erc1155supply fix

### DIFF
--- a/contracts/openzeppelin-presets/ERC1155PresetMinterPauserSupplyHolder.sol
+++ b/contracts/openzeppelin-presets/ERC1155PresetMinterPauserSupplyHolder.sol
@@ -63,60 +63,6 @@ contract ERC1155PresetMinterPauserSupplyHolder is
     }
 
     /**
-     * @dev See {ERC1155-_mint}.
-     */
-    function _mint(
-        address account,
-        uint256 id,
-        uint256 amount,
-        bytes memory data
-    ) internal virtual override {
-        super._mint(account, id, amount, data);
-        _totalSupply[id] += amount;
-    }
-
-    /**
-     * @dev See {ERC1155-_mintBatch}.
-     */
-    function _mintBatch(
-        address to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
-    ) internal virtual override {
-        super._mintBatch(to, ids, amounts, data);
-        for (uint256 i = 0; i < ids.length; ++i) {
-            _totalSupply[ids[i]] += amounts[i];
-        }
-    }
-
-    /**
-     * @dev See {ERC1155-_burn}.
-     */
-    function _burn(
-        address account,
-        uint256 id,
-        uint256 amount
-    ) internal virtual override {
-        super._burn(account, id, amount);
-        _totalSupply[id] -= amount;
-    }
-
-    /**
-     * @dev See {ERC1155-_burnBatch}.
-     */
-    function _burnBatch(
-        address account,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) internal virtual override {
-        super._burnBatch(account, ids, amounts);
-        for (uint256 i = 0; i < ids.length; ++i) {
-            _totalSupply[ids[i]] -= amounts[i];
-        }
-    }
-
-    /**
      * @dev Creates `amount` new tokens for `to`, of token type `id`.
      *
      * See {ERC1155-_mint}.
@@ -191,6 +137,9 @@ contract ERC1155PresetMinterPauserSupplyHolder is
         return super.supportsInterface(interfaceId);
     }
 
+    /**
+     * @dev See {ERC1155-_beforeTokenTransfer}.
+     */
     function _beforeTokenTransfer(
         address operator,
         address from,
@@ -200,5 +149,17 @@ contract ERC1155PresetMinterPauserSupplyHolder is
         bytes memory data
     ) internal virtual override(ERC1155, ERC1155Pausable) {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+
+        if (from == address(0)) {
+            for (uint256 i = 0; i < ids.length; ++i) {
+                _totalSupply[ids[i]] += amounts[i];
+            }
+        }
+
+        if (to == address(0)) {
+            for (uint256 i = 0; i < ids.length; ++i) {
+                _totalSupply[ids[i]] -= amounts[i];
+            }
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.12.0",
   "dependencies": {
     "@chainlink/contracts": "^0.2.2",
-    "@openzeppelin/contracts": "^4.3.2"
+    "@openzeppelin/contracts": "^4.3.3"
   },
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,10 +1717,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
-  integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
+"@openzeppelin/contracts@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"
+  integrity sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==
 
 "@parcel/babel-ast-utils@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Fixes https://github.com/nftlabs/nftlabs-protocols/issues/32

- Upgrades `@openzeppelin/contracts` from version `4.2.2` to `4.2.3`
- Matches `contracts/ERC1155PresetMinterPauserSupplyHolder.sol` with the fixed https://docs.openzeppelin.com/contracts/4.x/api/token/erc1155#ERC1155Supply