### PR TITLE
Bug fix: check for the intended total price when executing a direct listing sale

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -341,7 +341,7 @@ contract Marketplace is
         uint256 _currencyAmountToTransfer,
         uint256 _listingTokenAmountToTransfer
     ) internal {
-        validateDirectListingSale(_targetListing, _buyer, _listingTokenAmountToTransfer);
+        validateDirectListingSale(_targetListing, _buyer, _listingTokenAmountToTransfer, _currencyAmountToTransfer);
 
         _targetListing.quantity -= _listingTokenAmountToTransfer;
         listings[_targetListing.listingId] = _targetListing;
@@ -646,7 +646,8 @@ contract Marketplace is
     function validateDirectListingSale(
         Listing memory _listing,
         address _buyer,
-        uint256 _quantityToBuy
+        uint256 _quantityToBuy,
+        uint256 settledTotalPrice
     ) internal {
         require(_listing.listingType == ListingType.Direct, "Marketplace: cannot buy from listing.");
 
@@ -665,11 +666,11 @@ contract Marketplace is
         // Check: buyer owns and has approved sufficient currency for sale.
         if (_listing.currency == NATIVE_TOKEN) {
             require(
-                msg.value == _quantityToBuy * _listing.buyoutPricePerToken,
+                msg.value == settledTotalPrice,
                 "Marketplace: insufficient currency balance or allowance."
             );
         } else {
-            validateERC20BalAndAllowance(_buyer, _listing.currency, _quantityToBuy * _listing.buyoutPricePerToken);
+            validateERC20BalAndAllowance(_buyer, _listing.currency, settledTotalPrice);
         }
 
         // Check iwhether token owner owns and has approved `quantityToBuy` amount of listing tokens from the listing.


### PR DESCRIPTION
**Fix:** Checking for the total price settled upon (not necessarily the fixed price `buyoutPricePerToken * quantityToBuy`). 

Not doing so prevents a seller from accepting an offer that offers a price per token less than `buyoutPricePerToken`. See the buggy code, [here](https://github.com/nftlabs/nftlabs-protocols/blob/main/contracts/marketplace/Marketplace.sol#L665-L673).