### PR TITLE
SignatureMint: no need to predict tokenIds for new mints

### DIFF
--- a/contracts/signature_mint/ERC721/SignatureMint721.sol
+++ b/contracts/signature_mint/ERC721/SignatureMint721.sol
@@ -93,12 +93,6 @@ contract SignatureMint721 is
     /// @dev Mapping from end-tokenId => baseURI.
     mapping(uint256 => string) public baseURI;
 
-    /**
-     * @dev Mapping from baseURI => amount to subtract from tokenId to get `i` where URI for tokenId
-     *      is equal to `baseURI/i`.
-     */
-    mapping(string => uint256) private shiftForBaseURI;
-
     /// @dev Mapping from mint request UID => whether the mint request is processed.
     mapping(bytes32 => bool) private minted;
 
@@ -150,9 +144,13 @@ contract SignatureMint721 is
 
     /// @dev Returns the URI for a given tokenId.
     function tokenURI(uint256 _tokenId) public view override returns (string memory) {
+        uint256 shift = 0;
         for (uint256 i = 0; i < baseURIIndices.length; i += 1) {
             if (_tokenId < baseURIIndices[i]) {
-                uint256 toAppend = _tokenId - shiftForBaseURI[baseURI[baseURIIndices[i]]];
+                if (i > 0) {
+                    shift = baseURIIndices[i - 1];
+                }
+                uint256 toAppend = _tokenId - shift;
                 return string(abi.encodePacked(baseURI[baseURIIndices[i]], toAppend.toString()));
             }
         }
@@ -278,7 +276,6 @@ contract SignatureMint721 is
     ) internal {
         uint256 baseURIIndex = _startTokenIdToMint + _amountToMint;
         baseURI[baseURIIndex] = _baseURI;
-        shiftForBaseURI[_baseURI] = _startTokenIdToMint;
         baseURIIndices.push(baseURIIndex);
     }
 

--- a/contracts/signature_mint/ERC721/SignatureMint721.sol
+++ b/contracts/signature_mint/ERC721/SignatureMint721.sol
@@ -32,8 +32,6 @@ import "@openzeppelin/contracts/utils/Multicall.sol";
 import { IWETH } from "../../interfaces/IWETH.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "hardhat/console.sol";
-
 contract SignatureMint721 is
     ISignatureMint721,
     ERC721Enumerable,
@@ -154,8 +152,6 @@ contract SignatureMint721 is
     function tokenURI(uint256 _tokenId) public view override returns (string memory) {
         for (uint256 i = 0; i < baseURIIndices.length; i += 1) {
             if (_tokenId < baseURIIndices[i]) {
-                console.log("TokenId", _tokenId);
-                console.log("Shift", shiftForBaseURI[baseURI[baseURIIndices[i]]]);
                 uint256 toAppend = _tokenId - shiftForBaseURI[baseURI[baseURIIndices[i]]];
                 return string(abi.encodePacked(baseURI[baseURIIndices[i]], toAppend.toString()));
             }

--- a/test/SignatureMint/ERC721/mint/withERC20Token.ts
+++ b/test/SignatureMint/ERC721/mint/withERC20Token.ts
@@ -185,6 +185,17 @@ describe("Mint tokens with a valid mint request", function () {
 
       const uriForToken: string = await sigMint721.tokenURI(tokenIdToCheck);
       expect(uriForToken).to.equal(mintRequest.baseURI + tokenIdToCheck.toString());
+
+      // Generate another mint request. For the URI of the first new tokenId minted, should return `baseURI/0`
+      const anotherMintReq = { ...mintRequest, baseURI: "ipfs://test_2/", uid: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another string UID")), }
+      const signatureResult = await signMintRequest(protocolAdmin.provider, protocolAdmin, sigMint721, anotherMintReq);
+      const signatureForAnotherMint = signatureResult.signature;
+
+      const tokenIdToCheck_2: BigNumber = await sigMint721.nextTokenIdToMint();
+      await sigMint721.connect(requestor).mint(anotherMintReq, signatureForAnotherMint);
+
+      const uriForToken_2: string = await sigMint721.tokenURI(tokenIdToCheck_2);
+      expect(uriForToken_2).to.equal(anotherMintReq.baseURI + '0');
     });
   });
 });

--- a/test/SignatureMint/ERC721/mint/withNativeToken.ts
+++ b/test/SignatureMint/ERC721/mint/withNativeToken.ts
@@ -173,6 +173,17 @@ describe("Mint tokens with a valid mint request", function () {
 
       const uriForToken: string = await sigMint721.tokenURI(tokenIdToCheck);
       expect(uriForToken).to.equal(mintRequest.baseURI + tokenIdToCheck.toString());
+
+      // Generate another mint request. For the URI of the first new tokenId minted, should return `baseURI/0`
+      const anotherMintReq = { ...mintRequest, baseURI: "ipfs://test_2/", uid: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another string UID")), }
+      const signatureResult = await signMintRequest(protocolAdmin.provider, protocolAdmin, sigMint721, anotherMintReq);
+      const signatureForAnotherMint = signatureResult.signature;
+
+      const tokenIdToCheck_2: BigNumber = await sigMint721.nextTokenIdToMint();
+      await sigMint721.connect(requestor).mint(anotherMintReq, signatureForAnotherMint, { value: totalPrice });
+
+      const uriForToken_2: string = await sigMint721.tokenURI(tokenIdToCheck_2);
+      expect(uriForToken_2).to.equal(anotherMintReq.baseURI + '0');
     });
   });
 });


### PR DESCRIPTION
**What :** update to how the `tokenURI` is tracked for NFTs minted on the contract.

At the time of minting, the contract expects a `baseURI` to be applied to the NFTs being minted, such that if 5 NFTs are being minted (with tokenIds `0` to `4`), the tokenURI for an NFT with `0 <= tokenId <= 4` is that particular `baseURI + tokenId`.

**Problem with previous implementation :**

Since the URI generated for a directory of metadata json files is immutable, one must predict the tokenIds that will be assigned to the NFTs yet to mint, for `baseURI/tokenId` to resolve to the correct metadata.

This is buggy behaviour since a mint may be frontrun by another, which renders the passed `baseURI` useless for the actual tokenIds assigned to the NFTs minted.

**Fix :**

Each `baseURI` in a mint request should resolve `baseURI/{index}` starting at `index = 0`. So, if 5 NFTs are to be minted, then regardless of the tokenIds that will be assigned to the NFTs, the `baseURI` should be generated with the patter `baseURI/0` up to and including `baseURI/4`.

See the final test case in `test/SignatureMint/ERC721/mint/withNativeToken` for more clarity.