### PR TITLE
bug fix: enforce buyout price gte reserve price

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -184,6 +184,7 @@ contract Marketplace is
         // Can only edit auction listing before it starts.
         if (isAuction) {
             require(block.timestamp < targetListing.startTime, "Marketplace: auction already started.");
+            require(_buyoutPricePerToken >= _reservePricePerToken, "reserve price exceeds buyout price.");
         }
 
         uint256 newStartTime = _startTime == 0 ? targetListing.startTime : _startTime;

--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -160,6 +160,7 @@ contract Marketplace is
 
         // Tokens listed for sale in an auction are escrowed in Marketplace.
         if (newListing.listingType == ListingType.Auction) {
+            require(newListing.buyoutPricePerToken >= newListing.reservePricePerToken, "reserve price exceeds buyout price.");
             transferListingTokens(tokenOwner, address(this), tokenAmountToList, newListing);
         }
 

--- a/test/Marketplace/createAuctionListing.ts
+++ b/test/Marketplace/createAuctionListing.ts
@@ -115,6 +115,19 @@ describe("List token for sale: Auction Listing", function () {
         "Marketplace: insufficient token balance or approval.",
       );
     });
+
+    it("Should revert if reserve price exceeds buyout price", async () => {
+      // Invalid behaviour: listing 0 NFTs for auction.
+      const incorrectParams = {
+        ...listingParams,
+        buyoutPricePerToken: ethers.utils.parseEther("0.1"),
+        reservePricePerToken: ethers.utils.parseEther("0.2")
+      };
+
+      await expect(marketv2.connect(lister).createListing(incorrectParams)).to.be.revertedWith(
+        "reserve price exceeds buyout price.",
+      );
+    })
   });
 
   describe("Events", function () {


### PR DESCRIPTION
**Bug: **

Setting an auction listing's `buyoutPricePerToken < reservePricePerToken` results in an end user / bidder not being able to buyout the auction.

**Fix: **

At the time of listing creation, enforce  `buyoutPricePerToken >= reservePricePerToken`.