### PR TITLE
Sigmint1155 royalty

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -37,10 +37,11 @@ contract Marketplace is
     Multicall
 {
     /// @dev Version of the contract.
-    uint256 public constant VERSION = 1;
+    uint256 public constant VERSION = 2;
 
     /// @dev Access control: aditional roles.
     bytes32 public constant LISTER_ROLE = keccak256("LISTER_ROLE");
+    bytes32 public constant ASSET_ROLE = keccak256("ASSET_ROLE");
 
     /// @dev Top level control center contract.
     ProtocolControl internal controlCenter;
@@ -116,6 +117,7 @@ contract Marketplace is
 
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
         _setupRole(LISTER_ROLE, _msgSender());
+        _setupRole(ASSET_ROLE, address(0));
     }
 
     //  =====   External functions  =====
@@ -131,6 +133,10 @@ contract Marketplace is
         uint256 tokenAmountToList = getSafeQuantity(tokenTypeOfListing, _params.quantityToList);
 
         require(tokenAmountToList > 0, "Marketplace: listing invalid quantity.");
+        require(
+            hasRole(ASSET_ROLE, _params.assetContract) || hasRole(ASSET_ROLE, address(0)),
+            "Marketplace: listing unapproved asset"
+        );
 
         validateOwnershipAndApproval(
             tokenOwner,
@@ -160,7 +166,10 @@ contract Marketplace is
 
         // Tokens listed for sale in an auction are escrowed in Marketplace.
         if (newListing.listingType == ListingType.Auction) {
-            require(newListing.buyoutPricePerToken >= newListing.reservePricePerToken, "reserve price exceeds buyout price.");
+            require(
+                newListing.buyoutPricePerToken >= newListing.reservePricePerToken,
+                "reserve price exceeds buyout price."
+            );
             transferListingTokens(tokenOwner, address(this), tokenAmountToList, newListing);
         }
 

--- a/contracts/signature_mint/ERC1155/ISignatureMint1155.sol
+++ b/contracts/signature_mint/ERC1155/ISignatureMint1155.sol
@@ -22,6 +22,7 @@ interface ISignatureMint1155 {
     struct MintRequest {
         address to;
         address royaltyRecipient;
+        address primarySaleRecipient;
         uint256 tokenId;
         string uri;
         uint256 quantity;

--- a/contracts/signature_mint/ERC1155/ISignatureMint1155.sol
+++ b/contracts/signature_mint/ERC1155/ISignatureMint1155.sol
@@ -21,6 +21,7 @@ interface ISignatureMint1155 {
      */
     struct MintRequest {
         address to;
+        address royaltyRecipient;
         uint256 tokenId;
         string uri;
         uint256 quantity;
@@ -43,10 +44,15 @@ interface ISignatureMint1155 {
     );
 
     /// @dev Emitted when a new sale recipient is set.
-    event NewSaleRecipient(address indexed recipient, uint256 indexed _tokenId, bool isDefaultRecipient);
+    event NewSaleRecipient(address indexed recipient, uint256 indexed _tokenId);
+    /// @dev Emitted when a new sale recipient is set.
+    event NewRoyaltyRecipient(address indexed recipient, uint256 indexed _tokenId);
 
     /// @dev Emitted when a new sale recipient is set.
     event NewDefaultSaleRecipient(address indexed recipient);
+    
+    /// @dev Emitted when a new sale recipient is set.
+    event NewDefaultRoyaltyRecipient(address indexed recipient);
 
     /// @dev Emitted when the royalty fee bps is updated
     event RoyaltyUpdated(uint256 newRoyaltyBps);

--- a/contracts/signature_mint/ERC1155/SignatureMint1155.sol
+++ b/contracts/signature_mint/ERC1155/SignatureMint1155.sol
@@ -47,7 +47,7 @@ contract SignatureMint1155 is
 
     bytes32 private constant TYPEHASH =
         keccak256(
-            "MintRequest(address to,address to,uint256 tokenId,string uri,uint256 quantity,uint256 pricePerToken,address currency,uint128 validityStartTimestamp,uint128 validityEndTimestamp,bytes32 uid)"
+            "MintRequest(address to,address royaltyRecipient,uint256 tokenId,string uri,uint256 quantity,uint256 pricePerToken,address currency,uint128 validityStartTimestamp,uint128 validityEndTimestamp,bytes32 uid)"
         );
 
     /// @dev Only TRANSFER_ROLE holders can have tokens transferred from or to them, during restricted transfers.

--- a/contracts/signature_mint/ERC1155/SignatureMint1155.sol
+++ b/contracts/signature_mint/ERC1155/SignatureMint1155.sol
@@ -205,6 +205,10 @@ contract SignatureMint1155 is
             tokenIdToMint = _req.tokenId;
         }
 
+        if(_req.royaltyRecipient != address(0)) {
+            royaltyRecipient[tokenIdToMint] = _req.royaltyRecipient;
+        }
+
         _mintTo(receiver, _req.uri, tokenIdToMint, _req.quantity);
 
         collectPrice(_req, tokenIdToMint);

--- a/contracts/signature_mint/ERC1155/SignatureMint1155.sol
+++ b/contracts/signature_mint/ERC1155/SignatureMint1155.sol
@@ -47,7 +47,7 @@ contract SignatureMint1155 is
 
     bytes32 private constant TYPEHASH =
         keccak256(
-            "MintRequest(address to,address royaltyRecipient,uint256 tokenId,string uri,uint256 quantity,uint256 pricePerToken,address currency,uint128 validityStartTimestamp,uint128 validityEndTimestamp,bytes32 uid)"
+            "MintRequest(address to,address royaltyRecipient,address primarySaleRecipient,uint256 tokenId,string uri,uint256 quantity,uint256 pricePerToken,address currency,uint128 validityStartTimestamp,uint128 validityEndTimestamp,bytes32 uid)"
         );
 
     /// @dev Only TRANSFER_ROLE holders can have tokens transferred from or to them, during restricted transfers.
@@ -208,6 +208,9 @@ contract SignatureMint1155 is
         if(_req.royaltyRecipient != address(0)) {
             royaltyRecipient[tokenIdToMint] = _req.royaltyRecipient;
         }
+        if(_req.primarySaleRecipient != address(0)) {
+            saleRecipient[tokenIdToMint] = _req.primarySaleRecipient;
+        }
 
         _mintTo(receiver, _req.uri, tokenIdToMint, _req.quantity);
 
@@ -329,6 +332,7 @@ contract SignatureMint1155 is
             TYPEHASH,
             _req.to,
             _req.royaltyRecipient,
+            _req.primarySaleRecipient,
             _req.tokenId,
             keccak256(bytes(_req.uri)),
             _req.quantity,

--- a/test/SignatureMint/ERC1155/deploy.ts
+++ b/test/SignatureMint/ERC1155/deploy.ts
@@ -28,6 +28,7 @@ describe("Initial state of SignatureMint1155 on deployment", function () {
   let trustedForwarderAddr: string;
   let protocolControlAddr: string;
   let nativeTokenWrapperAddr: string;
+  let royaltyRecipient: string;
   const royaltyBps: BigNumber = BigNumber.from(0);
   const feeBps: BigNumber = BigNumber.from(0);
 
@@ -41,6 +42,7 @@ describe("Initial state of SignatureMint1155 on deployment", function () {
     trustedForwarderAddr = contracts.forwarder.address;
     protocolControlAddr = contracts.protocolControl.address;
     nativeTokenWrapperAddr = contracts.weth.address;
+    royaltyRecipient = protocolAdmin.address;
 
     sigMint1155 = (await ethers
       .getContractFactory("SignatureMint1155")
@@ -53,6 +55,7 @@ describe("Initial state of SignatureMint1155 on deployment", function () {
             trustedForwarderAddr,
             nativeTokenWrapperAddr,
             defaultSaleRecipient.address,
+            royaltyRecipient,
             royaltyBps,
             feeBps,
           ),

--- a/test/SignatureMint/ERC1155/mint/utils/sign.js
+++ b/test/SignatureMint/ERC1155/mint/utils/sign.js
@@ -10,6 +10,7 @@ const EIP712Domain = [
 const MintRequest = [
   { name: "to", type: "address" },
   { name: "royaltyRecipient", type: "address" },
+  { name: "primarySaleRecipient", type: "address" },
   { name: "tokenId", type: "uint256" },
   { name: "uri", type: "string" },
   { name: "quantity", type: "uint256" },

--- a/test/SignatureMint/ERC1155/mint/utils/sign.js
+++ b/test/SignatureMint/ERC1155/mint/utils/sign.js
@@ -9,6 +9,7 @@ const EIP712Domain = [
 
 const MintRequest = [
   { name: "to", type: "address" },
+  { name: "royaltyRecipient", type: "address" },
   { name: "tokenId", type: "uint256" },
   { name: "uri", type: "string" },
   { name: "quantity", type: "uint256" },

--- a/test/SignatureMint/ERC1155/mint/withERC20Token.ts
+++ b/test/SignatureMint/ERC1155/mint/withERC20Token.ts
@@ -55,6 +55,7 @@ describe("Mint tokens with a valid mint request", function () {
 
     mintRequest = {
       to: requestor.address,
+      royaltyRecipient: protocolAdmin.address,
       tokenId: ethers.constants.MaxUint256.toString(),
       uri: "ipfs://test/",
       quantity: 10,
@@ -145,6 +146,7 @@ describe("Mint tokens with a valid mint request", function () {
             tokenIdMinted: tokenIdToBeMinted,
             mintRequest: Object.values({
               to: mintRequest.to,
+              royaltyRecipient: mintRequest.royaltyRecipient,
               tokenId: mintRequest.tokenId,
               uri: mintRequest.uri,
               quantity: mintRequest.quantity,

--- a/test/SignatureMint/ERC1155/mint/withERC20Token.ts
+++ b/test/SignatureMint/ERC1155/mint/withERC20Token.ts
@@ -56,6 +56,7 @@ describe("Mint tokens with a valid mint request", function () {
     mintRequest = {
       to: requestor.address,
       royaltyRecipient: protocolAdmin.address,
+      primarySaleRecipient: protocolAdmin.address,
       tokenId: ethers.constants.MaxUint256.toString(),
       uri: "ipfs://test/",
       quantity: 10,
@@ -147,6 +148,7 @@ describe("Mint tokens with a valid mint request", function () {
             mintRequest: Object.values({
               to: mintRequest.to,
               royaltyRecipient: mintRequest.royaltyRecipient,
+              primarySaleRecipient: mintRequest.primarySaleRecipient,
               tokenId: mintRequest.tokenId,
               uri: mintRequest.uri,
               quantity: mintRequest.quantity,

--- a/test/SignatureMint/ERC1155/mint/withNativeToken.ts
+++ b/test/SignatureMint/ERC1155/mint/withNativeToken.ts
@@ -47,6 +47,7 @@ describe("Mint tokens with a valid mint request", function () {
     mintRequest = {
       to: requestor.address,
       royaltyRecipient: protocolAdmin.address,
+      primarySaleRecipient: protocolAdmin.address,
       tokenId: ethers.constants.MaxUint256.toString(),
       uri: "ipfs://test/",
       quantity: 10,
@@ -143,6 +144,7 @@ describe("Mint tokens with a valid mint request", function () {
             mintRequest: Object.values({
               to: mintRequest.to,
               royaltyRecipient: mintRequest.royaltyRecipient,
+              primarySaleRecipient: mintRequest.primarySaleRecipient,
               tokenId: mintRequest.tokenId,
               uri: mintRequest.uri,
               quantity: mintRequest.quantity,

--- a/test/SignatureMint/ERC1155/mint/withNativeToken.ts
+++ b/test/SignatureMint/ERC1155/mint/withNativeToken.ts
@@ -46,6 +46,7 @@ describe("Mint tokens with a valid mint request", function () {
 
     mintRequest = {
       to: requestor.address,
+      royaltyRecipient: protocolAdmin.address,
       tokenId: ethers.constants.MaxUint256.toString(),
       uri: "ipfs://test/",
       quantity: 10,
@@ -141,6 +142,7 @@ describe("Mint tokens with a valid mint request", function () {
             tokenIdMinted: tokenIdToBeMinted,
             mintRequest: Object.values({
               to: mintRequest.to,
+              royaltyRecipient: mintRequest.royaltyRecipient,
               tokenId: mintRequest.tokenId,
               uri: mintRequest.uri,
               quantity: mintRequest.quantity,

--- a/utils/tests/getContracts.ts
+++ b/utils/tests/getContracts.ts
@@ -234,6 +234,7 @@ export async function getContracts(
           trustedForwarderAddr,
           nativeTokenWrapperAddr,
           defaultSaleRecipient,
+          protocolAdmin.address,
           royaltyBps,
           feeBps,
         ),


### PR DESCRIPTION
- `MintRequest` includes a `royaltyRecipient` field -- the address of the recipient of royalties for the minted token ID.
- Adds `setRoyaltyRecipient` for module admin to override the the recipient of royalties for the minted token ID.
- If no `royaltyRecipient` is set in a `MintRequest` or `setRoyaltyRecipient`, then royalties for the relevant token ID go to the `defaultRoyaltyRecipient`; this address is updatable by the module admin at `setDefaultRoyaltyRecipient`.